### PR TITLE
Add Intercom-header to v2.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ const Events = require('./resources/events')
 
 class Intercom {
   /**
-   * 
-   * @param {String} apiKey 
+   *
+   * @param {String} apiKey
    */
   constructor(apiKey) {
     this.apiKey = apiKey
@@ -18,9 +18,10 @@ class Intercom {
         'Authorization': `Bearer ${this.apiKey}`,
         'Accept': 'application/json',
         'Content-Type': 'application/json',
+        'Intercom-version': '2.0',
       }
     })
-    
+
     this.contacts = new Contacts(this.client)
     this.tags = new Tags(this.client)
     this.visitors = new Visitors(this.client)


### PR DESCRIPTION
Hi, I've been encounter the following response while using the client when using the `contacts.search` function. 

```json
{
    "errors": [
        {
            "code": "not_found",
            "message": "The requested resource does not exist; check your path and try again"
        }
    ],
    "type": "error.list"
}
```

This happens when the header `Intercom-version` is not set to 2.0. As you may see in the following support ticket: 
https://community.intercom.com/t/search-contacts-api-returns-404-for-wrong-token/1866

This PR just adds that header. Please do a code revision and merge accordingly 😄 

P.S.: Thanks for this client!